### PR TITLE
Add project creation on admin dashboard

### DIFF
--- a/Web/crear_proyecto.php
+++ b/Web/crear_proyecto.php
@@ -1,0 +1,30 @@
+<?php
+require_once 'db.php';
+require_once 'auth.php';
+
+requerirLogin();
+if (!esSuperAdmin()) exit("Acceso denegado");
+
+if (empty($_POST['nombre_proyecto'])) {
+    exit("El nombre del proyecto es obligatorio.");
+}
+
+$nombre = trim($_POST['nombre_proyecto']);
+$descripcion = trim($_POST['descripcion'] ?? '');
+$creador = $_SESSION['usuario_id'];
+
+$pdo->prepare("INSERT INTO proyectos (nombre, descripcion, creador_id) VALUES (?, ?, ?)")
+    ->execute([$nombre, $descripcion, $creador]);
+$proyecto_id = $pdo->lastInsertId();
+
+if (!empty($_POST['usuarios_seleccionados'])) {
+    $stmt = $pdo->prepare("INSERT INTO proyecto_usuario (proyecto_id, usuario_id) VALUES (?, ?)");
+    foreach ($_POST['usuarios_seleccionados'] as $uid) {
+        $stmt->execute([$proyecto_id, $uid]);
+    }
+}
+
+header("Location: dashboard_admin.php?tab=proyectos");
+exit;
+?>
+

--- a/Web/dashboard_admin.php
+++ b/Web/dashboard_admin.php
@@ -158,12 +158,28 @@ $tab = $_GET['tab'] ?? 'empresas';
         </table>
 
       <?php elseif ($tab === 'proyectos'): ?>
+        <h2>Nuevo proyecto</h2>
+        <form action="crear_proyecto.php" method="POST">
+          <input type="text" name="nombre_proyecto" required placeholder="Nombre del proyecto">
+          <br>
+          <textarea name="descripcion" placeholder="Descripci&oacute;n"></textarea>
+          <br>
+          <h3>Asignar usuarios</h3>
+          <?php foreach ($usuarios as $u): ?>
+            <label>
+              <input type="checkbox" name="usuarios_seleccionados[]" value="<?= $u['id'] ?>">
+              <?= htmlspecialchars($u['nombre'] . ' ' . $u['apellido_paterno']) ?> (<?= htmlspecialchars($u['email']) ?>)
+            </label><br>
+          <?php endforeach; ?>
+          <button>Crear</button>
+        </form>
+
         <h2>Proyectos iniciados</h2>
         <table>
           <tr>
             <th>ID</th>
             <th>Nombre</th>
-            <th>Descripción</th>
+            <th>Descripci&oacute;n</th>
             <th>Participantes</th>
           </tr>
           <?php foreach ($proyectos as $p): ?>


### PR DESCRIPTION
## Summary
- allow admins to create projects from the Projects tab
- enable assigning existing users while creating a project

## Testing
- `php -l Web/crear_proyecto.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684960eb73148327ae0c0c8b88f9e67c