### PR TITLE
Add estado field for projects

### DIFF
--- a/DB/DB.sql
+++ b/DB/DB.sql
@@ -53,6 +53,7 @@ CREATE TABLE proyectos (
   id INT AUTO_INCREMENT PRIMARY KEY,
   nombre VARCHAR(255) NOT NULL,
   descripcion TEXT,
+  estado ENUM('No iniciado', 'Iniciado', 'Pausado', 'Finalizado') NOT NULL DEFAULT 'No iniciado',
   creador_id INT NOT NULL,
   FOREIGN KEY (creador_id) REFERENCES usuarios(id) ON DELETE CASCADE ON UPDATE CASCADE
 );

--- a/Web/crear_proyecto.php
+++ b/Web/crear_proyecto.php
@@ -11,10 +11,11 @@ if (empty($_POST['nombre_proyecto'])) {
 
 $nombre = trim($_POST['nombre_proyecto']);
 $descripcion = trim($_POST['descripcion'] ?? '');
+$estado = $_POST['estado'] ?? 'No iniciado';
 $creador = $_SESSION['usuario_id'];
 
-$pdo->prepare("INSERT INTO proyectos (nombre, descripcion, creador_id) VALUES (?, ?, ?)")
-    ->execute([$nombre, $descripcion, $creador]);
+$pdo->prepare("INSERT INTO proyectos (nombre, descripcion, estado, creador_id) VALUES (?, ?, ?, ?)")
+    ->execute([$nombre, $descripcion, $estado, $creador]);
 $proyecto_id = $pdo->lastInsertId();
 
 if (!empty($_POST['usuarios_seleccionados'])) {

--- a/Web/dashboard_admin.php
+++ b/Web/dashboard_admin.php
@@ -28,6 +28,7 @@ $proyectos = $pdo->query("
   SELECT p.id,
          p.nombre,
          p.descripcion,
+         p.estado,
          GROUP_CONCAT(CONCAT(u.nombre, ' ', u.apellido_paterno) SEPARATOR ', ') AS participantes
   FROM proyectos p
   LEFT JOIN proyecto_usuario pu ON p.id = pu.proyecto_id
@@ -164,6 +165,15 @@ $tab = $_GET['tab'] ?? 'empresas';
           <br>
           <textarea name="descripcion" placeholder="Descripci&oacute;n"></textarea>
           <br>
+          <label>Estado:
+            <select name="estado">
+              <option value="No iniciado">No iniciado</option>
+              <option value="Iniciado">Iniciado</option>
+              <option value="Pausado">Pausado</option>
+              <option value="Finalizado">Finalizado</option>
+            </select>
+          </label>
+          <br>
           <h3>Asignar usuarios</h3>
           <?php foreach ($usuarios as $u): ?>
             <label>
@@ -180,6 +190,7 @@ $tab = $_GET['tab'] ?? 'empresas';
             <th>ID</th>
             <th>Nombre</th>
             <th>Descripci&oacute;n</th>
+            <th>Estado</th>
             <th>Participantes</th>
           </tr>
           <?php foreach ($proyectos as $p): ?>
@@ -187,6 +198,7 @@ $tab = $_GET['tab'] ?? 'empresas';
               <td><?= htmlspecialchars($p['id']) ?></td>
               <td><?= htmlspecialchars($p['nombre']) ?></td>
               <td><?= htmlspecialchars($p['descripcion']) ?></td>
+              <td><?= htmlspecialchars($p['estado']) ?></td>
               <td><?= htmlspecialchars($p['participantes']) ?></td>
             </tr>
           <?php endforeach; ?>


### PR DESCRIPTION
## Summary
- add `estado` column to projects table
- include project status when creating projects in admin dashboard
- display project status on admin dashboard

## Testing
- `php -l Web/dashboard_admin.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6849644300ac8327afbfb27eafe3a72a