### PR TITLE
Add group management to admin dashboard

### DIFF
--- a/DB/DB.sql
+++ b/DB/DB.sql
@@ -3,10 +3,18 @@ CREATE DATABASE IF NOT EXISTS SkillTracker CHARACTER SET utf8mb4 COLLATE utf8mb4
 
 USE SkillTracker;
 
+-- Tabla de grupos
+CREATE TABLE grupos (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  nombre VARCHAR(255) NOT NULL UNIQUE
+);
+
 -- Tabla de empresas
 CREATE TABLE empresas (
   id INT AUTO_INCREMENT PRIMARY KEY,
-  nombre VARCHAR(255) NOT NULL UNIQUE
+  nombre VARCHAR(255) NOT NULL UNIQUE,
+  grupo_id INT DEFAULT NULL,
+  FOREIGN KEY (grupo_id) REFERENCES grupos(id) ON DELETE SET NULL ON UPDATE CASCADE
 );
 
 -- Tabla de oficinas
@@ -69,8 +77,11 @@ CREATE TABLE proyecto_usuario (
 
 -- === Datos iniciales ===
 
+-- Grupo inicial
+INSERT INTO grupos (nombre) VALUES ('Grupo Principal');
+
 -- Empresa inicial
-INSERT INTO empresas (nombre) VALUES ('Empresa Principal');
+INSERT INTO empresas (nombre, grupo_id) VALUES ('Empresa Principal', 1);
 
 -- Oficina inicial
 INSERT INTO oficinas (nombre, ciudad) VALUES ('Oficina Central', 'Madrid');

--- a/Web/empresas.php
+++ b/Web/empresas.php
@@ -6,8 +6,8 @@ requerirLogin();
 if (!esSuperAdmin()) exit("Acceso denegado");
 
 // Verificar que el nombre no esté vacío
-if (empty($_POST['nombre_empresa'])) {
-  exit("El nombre de la empresa no puede estar vacío.");
+if (empty($_POST['nombre_empresa']) || empty($_POST['grupo_id'])) {
+  exit("Faltan datos obligatorios.");
 }
 
 // Limpiar y normalizar
@@ -21,8 +21,15 @@ if ($stmt->fetchColumn() > 0) {
 }
 
 // Insertar la empresa
-$stmt = $pdo->prepare("INSERT INTO empresas (nombre) VALUES (?)");
-$stmt->execute([$nombre]);
+$grupo_id = (int)$_POST['grupo_id'];
+$stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE id = ?");
+$stmt->execute([$grupo_id]);
+if ($stmt->fetchColumn() == 0) {
+  exit("Grupo no válido.");
+}
+
+$stmt = $pdo->prepare("INSERT INTO empresas (nombre, grupo_id) VALUES (?, ?)");
+$stmt->execute([$nombre, $grupo_id]);
 
 header("Location: dashboard_admin.php");
 exit;

--- a/Web/grupos.php
+++ b/Web/grupos.php
@@ -1,0 +1,48 @@
+<?php
+require_once 'db.php';
+require_once 'auth.php';
+
+requerirLogin();
+if (!esSuperAdmin()) exit("Acceso denegado");
+
+if (isset($_POST['nombre_grupo'])) {
+    $nombre = trim($_POST['nombre_grupo']);
+    if ($nombre === '') {
+        exit("El nombre del grupo no puede estar vacío.");
+    }
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE nombre = ?");
+    $stmt->execute([$nombre]);
+    if ($stmt->fetchColumn() > 0) {
+        exit("Ya existe un grupo con ese nombre.");
+    }
+    $stmt = $pdo->prepare("INSERT INTO grupos (nombre) VALUES (?)");
+    $stmt->execute([$nombre]);
+    header("Location: dashboard_admin.php?tab=grupos");
+    exit;
+}
+
+if (isset($_POST['grupo_id'], $_POST['empresa_id'])) {
+    $grupo_id = (int)$_POST['grupo_id'];
+    $empresa_id = (int)$_POST['empresa_id'];
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE id = ?");
+    $stmt->execute([$grupo_id]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Grupo no válido.");
+    }
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM empresas WHERE id = ?");
+    $stmt->execute([$empresa_id]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Empresa no válida.");
+    }
+
+    $stmt = $pdo->prepare("UPDATE empresas SET grupo_id = ? WHERE id = ?");
+    $stmt->execute([$grupo_id, $empresa_id]);
+    header("Location: dashboard_admin.php?tab=grupos");
+    exit;
+}
+
+header("Location: dashboard_admin.php");
+exit;
+?>


### PR DESCRIPTION
## Summary
- create `grupos` table and link companies with groups in `DB.sql`
- add new `grupos.php` handler
- show and manage groups from the admin dashboard
- allow assigning a group when creating a company

## Testing
- `php` commands not available, no tests run

------
https://chatgpt.com/codex/tasks/task_e_6849698e66d08327ba429c2429489118