### PR TITLE
Add groups listing and rename feature

### DIFF
--- a/Web/dashboard_admin.php
+++ b/Web/dashboard_admin.php
@@ -13,7 +13,13 @@ if (!esSuperAdmin()) {
   exit;
 }
 
-$grupos = $pdo->query("SELECT * FROM grupos ORDER BY id ASC")->fetchAll();
+$grupos = $pdo->query(
+  "SELECT g.*, GROUP_CONCAT(e.nombre ORDER BY e.id ASC SEPARATOR ', ') AS empresas
+   FROM grupos g
+   LEFT JOIN empresas e ON e.grupo_id = g.id
+   GROUP BY g.id
+   ORDER BY g.id ASC"
+)->fetchAll();
 $empresas = $pdo->query(
   "SELECT empresas.*, grupos.nombre AS grupo_nombre
    FROM empresas
@@ -77,6 +83,25 @@ $tab = $_GET['tab'] ?? 'empresas';
           <input type="text" name="nombre_grupo" required>
           <button>Crear</button>
         </form>
+
+        <h2>Grupos registrados</h2>
+        <table>
+          <tr><th>ID</th><th>Nombre</th><th>Empresas</th><th>Renombrar</th></tr>
+          <?php foreach ($grupos as $g): ?>
+            <tr>
+              <td><?= htmlspecialchars($g['id']) ?></td>
+              <td><?= htmlspecialchars($g['nombre']) ?></td>
+              <td><?= htmlspecialchars($g['empresas']) ?></td>
+              <td>
+                <form action="grupos.php" method="POST">
+                  <input type="hidden" name="editar_grupo_id" value="<?= $g['id'] ?>">
+                  <input type="text" name="nuevo_nombre" required placeholder="Nuevo nombre">
+                  <button>Cambiar</button>
+                </form>
+              </td>
+            </tr>
+          <?php endforeach; ?>
+        </table>
 
         <h2>Asignar empresas a grupos</h2>
         <?php foreach ($grupos as $g): ?>

--- a/Web/grupos.php
+++ b/Web/grupos.php
@@ -21,6 +21,28 @@ if (isset($_POST['nombre_grupo'])) {
     exit;
 }
 
+if (isset($_POST['editar_grupo_id'], $_POST['nuevo_nombre'])) {
+    $grupo_id = (int)$_POST['editar_grupo_id'];
+    $nuevo_nombre = trim($_POST['nuevo_nombre']);
+    if ($nuevo_nombre === '') {
+        exit("El nombre del grupo no puede estar vacío.");
+    }
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE id = ?");
+    $stmt->execute([$grupo_id]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Grupo no válido.");
+    }
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE nombre = ? AND id != ?");
+    $stmt->execute([$nuevo_nombre, $grupo_id]);
+    if ($stmt->fetchColumn() > 0) {
+        exit("Ya existe un grupo con ese nombre.");
+    }
+    $stmt = $pdo->prepare("UPDATE grupos SET nombre = ? WHERE id = ?");
+    $stmt->execute([$nuevo_nombre, $grupo_id]);
+    header("Location: dashboard_admin.php?tab=grupos");
+    exit;
+}
+
 if (isset($_POST['grupo_id'], $_POST['empresa_id'])) {
     $grupo_id = (int)$_POST['grupo_id'];
     $empresa_id = (int)$_POST['empresa_id'];


### PR DESCRIPTION
## Summary
- list groups with their companies in the admin dashboard
- allow renaming groups

## Testing
- `php -l Web/dashboard_admin.php` *(fails: php not installed)*


------
https://chatgpt.com/codex/tasks/task_e_68496cadefa08327a92d008406aeaf36