### PR TITLE
Add company rename to admin dashboard

### DIFF
--- a/Web/dashboard_admin.php
+++ b/Web/dashboard_admin.php
@@ -131,12 +131,19 @@ $tab = $_GET['tab'] ?? 'empresas';
 
         <h2>Empresas registradas</h2>
         <table>
-          <tr><th>ID</th><th>Nombre</th><th>Grupo</th></tr>
+          <tr><th>ID</th><th>Nombre</th><th>Grupo</th><th>Renombrar</th></tr>
           <?php foreach ($empresas as $e): ?>
             <tr>
               <td><?= htmlspecialchars($e['id']) ?></td>
               <td><?= htmlspecialchars($e['nombre']) ?></td>
               <td><?= htmlspecialchars($e['grupo_nombre']) ?></td>
+              <td>
+                <form action="empresas.php" method="POST">
+                  <input type="hidden" name="editar_empresa_id" value="<?= $e['id'] ?>">
+                  <input type="text" name="nuevo_nombre" required placeholder="Nuevo nombre">
+                  <button>Cambiar</button>
+                </form>
+              </td>
             </tr>
           <?php endforeach; ?>
         </table>

--- a/Web/empresas.php
+++ b/Web/empresas.php
@@ -5,22 +5,47 @@ require_once 'auth.php';
 requerirLogin();
 if (!esSuperAdmin()) exit("Acceso denegado");
 
-// Verificar que el nombre no esté vacío
+// Renombrar empresa
+if (isset($_POST['editar_empresa_id'], $_POST['nuevo_nombre'])) {
+  $empresa_id = (int)$_POST['editar_empresa_id'];
+  $nuevo_nombre = trim($_POST['nuevo_nombre']);
+
+  if ($nuevo_nombre === '') {
+    exit("El nombre de la empresa no puede estar vacío.");
+  }
+
+  $stmt = $pdo->prepare("SELECT COUNT(*) FROM empresas WHERE id = ?");
+  $stmt->execute([$empresa_id]);
+  if ($stmt->fetchColumn() == 0) {
+    exit("Empresa no válida.");
+  }
+
+  $stmt = $pdo->prepare("SELECT COUNT(*) FROM empresas WHERE nombre = ? AND id != ?");
+  $stmt->execute([$nuevo_nombre, $empresa_id]);
+  if ($stmt->fetchColumn() > 0) {
+    exit("Ya existe una empresa con ese nombre.");
+  }
+
+  $stmt = $pdo->prepare("UPDATE empresas SET nombre = ? WHERE id = ?");
+  $stmt->execute([$nuevo_nombre, $empresa_id]);
+
+  header("Location: dashboard_admin.php?tab=empresas");
+  exit;
+}
+
+// Crear nueva empresa
 if (empty($_POST['nombre_empresa']) || empty($_POST['grupo_id'])) {
   exit("Faltan datos obligatorios.");
 }
 
-// Limpiar y normalizar
 $nombre = trim($_POST['nombre_empresa']);
 
-// Comprobar si ya existe una empresa con ese nombre
 $stmt = $pdo->prepare("SELECT COUNT(*) FROM empresas WHERE nombre = ?");
 $stmt->execute([$nombre]);
 if ($stmt->fetchColumn() > 0) {
   exit("Ya existe una empresa con ese nombre.");
 }
 
-// Insertar la empresa
 $grupo_id = (int)$_POST['grupo_id'];
 $stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE id = ?");
 $stmt->execute([$grupo_id]);
@@ -31,6 +56,6 @@ if ($stmt->fetchColumn() == 0) {
 $stmt = $pdo->prepare("INSERT INTO empresas (nombre, grupo_id) VALUES (?, ?)");
 $stmt->execute([$nombre, $grupo_id]);
 
-header("Location: dashboard_admin.php");
+header("Location: dashboard_admin.php?tab=empresas");
 exit;
 ?>


### PR DESCRIPTION
## Summary
- enable renaming companies from the admin panel
- process rename requests in empresas.php

## Testing
- `php -l Web/dashboard_admin.php`
- `php -l Web/empresas.php`


------
https://chatgpt.com/codex/tasks/task_e_684985642e4483279d417fb816efdd02