### PR TITLE
Add delete actions for groups and companies

### DIFF
--- a/Web/dashboard_admin.php
+++ b/Web/dashboard_admin.php
@@ -86,7 +86,7 @@ $tab = $_GET['tab'] ?? 'empresas';
 
         <h2>Grupos registrados</h2>
         <table>
-          <tr><th>ID</th><th>Nombre</th><th>Empresas</th><th>Renombrar</th></tr>
+          <tr><th>ID</th><th>Nombre</th><th>Empresas</th><th>Renombrar</th><th>Eliminar</th></tr>
           <?php foreach ($grupos as $g): ?>
             <tr>
               <td><?= htmlspecialchars($g['id']) ?></td>
@@ -97,6 +97,12 @@ $tab = $_GET['tab'] ?? 'empresas';
                   <input type="hidden" name="editar_grupo_id" value="<?= $g['id'] ?>">
                   <input type="text" name="nuevo_nombre" required placeholder="Nuevo nombre">
                   <button>Cambiar</button>
+                </form>
+              </td>
+              <td>
+                <form action="grupos.php" method="POST" onsubmit="return confirm('¿Borrar grupo?');">
+                  <input type="hidden" name="eliminar_grupo_id" value="<?= $g['id'] ?>">
+                  <button>Eliminar</button>
                 </form>
               </td>
             </tr>
@@ -131,7 +137,7 @@ $tab = $_GET['tab'] ?? 'empresas';
 
         <h2>Empresas registradas</h2>
         <table>
-          <tr><th>ID</th><th>Nombre</th><th>Grupo</th><th>Renombrar</th></tr>
+          <tr><th>ID</th><th>Nombre</th><th>Grupo</th><th>Renombrar</th><th>Eliminar</th></tr>
           <?php foreach ($empresas as $e): ?>
             <tr>
               <td><?= htmlspecialchars($e['id']) ?></td>
@@ -142,6 +148,12 @@ $tab = $_GET['tab'] ?? 'empresas';
                   <input type="hidden" name="editar_empresa_id" value="<?= $e['id'] ?>">
                   <input type="text" name="nuevo_nombre" required placeholder="Nuevo nombre">
                   <button>Cambiar</button>
+                </form>
+              </td>
+              <td>
+                <form action="empresas.php" method="POST" onsubmit="return confirm('¿Borrar empresa?');">
+                  <input type="hidden" name="eliminar_empresa_id" value="<?= $e['id'] ?>">
+                  <button>Eliminar</button>
                 </form>
               </td>
             </tr>

--- a/Web/empresas.php
+++ b/Web/empresas.php
@@ -5,6 +5,30 @@ require_once 'auth.php';
 requerirLogin();
 if (!esSuperAdmin()) exit("Acceso denegado");
 
+// Eliminar empresa
+if (isset($_POST['eliminar_empresa_id'])) {
+  $empresa_id = (int)$_POST['eliminar_empresa_id'];
+
+  $stmt = $pdo->prepare("SELECT COUNT(*) FROM empresas WHERE id = ?");
+  $stmt->execute([$empresa_id]);
+  if ($stmt->fetchColumn() == 0) {
+    exit("Empresa no válida.");
+  }
+
+  // Comprobar que no haya usuarios asociados
+  $stmt = $pdo->prepare("SELECT COUNT(*) FROM usuarios WHERE empresa_id = ?");
+  $stmt->execute([$empresa_id]);
+  if ($stmt->fetchColumn() > 0) {
+    exit("No se puede eliminar la empresa porque tiene usuarios asociados.");
+  }
+
+  $stmt = $pdo->prepare("DELETE FROM empresas WHERE id = ?");
+  $stmt->execute([$empresa_id]);
+
+  header("Location: dashboard_admin.php?tab=empresas");
+  exit;
+}
+
 // Renombrar empresa
 if (isset($_POST['editar_empresa_id'], $_POST['nuevo_nombre'])) {
   $empresa_id = (int)$_POST['editar_empresa_id'];

--- a/Web/grupos.php
+++ b/Web/grupos.php
@@ -5,6 +5,22 @@ require_once 'auth.php';
 requerirLogin();
 if (!esSuperAdmin()) exit("Acceso denegado");
 
+if (isset($_POST['eliminar_grupo_id'])) {
+    $grupo_id = (int)$_POST['eliminar_grupo_id'];
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE id = ?");
+    $stmt->execute([$grupo_id]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Grupo no válido.");
+    }
+
+    $stmt = $pdo->prepare("DELETE FROM grupos WHERE id = ?");
+    $stmt->execute([$grupo_id]);
+
+    header("Location: dashboard_admin.php?tab=grupos");
+    exit;
+}
+
 if (isset($_POST['nombre_grupo'])) {
     $nombre = trim($_POST['nombre_grupo']);
     if ($nombre === '') {


### PR DESCRIPTION
## Summary
- allow deleting groups via *dashboard_admin*
- allow deleting companies via *dashboard_admin*
- implement endpoints in `grupos.php` and `empresas.php` to process deletions

## Testing
- `php -l Web/grupos.php`
- `php -l Web/empresas.php`
- `php -l Web/dashboard_admin.php`


------
https://chatgpt.com/codex/tasks/task_e_684986e362a0832798e937ac3162e7a5