### PR TITLE
Allow companies without group assignment

### DIFF
--- a/Web/dashboard_admin.php
+++ b/Web/dashboard_admin.php
@@ -118,7 +118,8 @@ $tab = $_GET['tab'] ?? 'empresas';
         <h2>Nueva empresa</h2>
         <form action="empresas.php" method="POST">
           <input type="text" name="nombre_empresa" required>
-          <select name="grupo_id" required>
+          <select name="grupo_id">
+            <option value="">Ninguno</option>
             <?php foreach ($grupos as $g): ?>
               <option value="<?= $g['id'] ?>"><?= htmlspecialchars($g['nombre']) ?></option>
             <?php endforeach; ?>
@@ -133,7 +134,7 @@ $tab = $_GET['tab'] ?? 'empresas';
             <tr>
               <td><?= htmlspecialchars($e['id']) ?></td>
               <td><?= htmlspecialchars($e['nombre']) ?></td>
-              <td><?= htmlspecialchars($e['grupo_nombre']) ?></td>
+              <td><?= htmlspecialchars($e['grupo_nombre'] ?? 'Ninguno') ?></td>
               <td>
                 <form action="empresas.php" method="POST">
                   <input type="hidden" name="editar_empresa_id" value="<?= $e['id'] ?>">

--- a/Web/empresas.php
+++ b/Web/empresas.php
@@ -58,7 +58,7 @@ if (isset($_POST['editar_empresa_id'], $_POST['nuevo_nombre'])) {
 }
 
 // Crear nueva empresa
-if (empty($_POST['nombre_empresa']) || empty($_POST['grupo_id'])) {
+if (empty($_POST['nombre_empresa'])) {
   exit("Faltan datos obligatorios.");
 }
 
@@ -70,11 +70,15 @@ if ($stmt->fetchColumn() > 0) {
   exit("Ya existe una empresa con ese nombre.");
 }
 
-$grupo_id = (int)$_POST['grupo_id'];
-$stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE id = ?");
-$stmt->execute([$grupo_id]);
-if ($stmt->fetchColumn() == 0) {
-  exit("Grupo no válido.");
+
+$grupo_id = null;
+if (isset($_POST['grupo_id']) && $_POST['grupo_id'] !== '') {
+  $grupo_id = (int)$_POST['grupo_id'];
+  $stmt = $pdo->prepare("SELECT COUNT(*) FROM grupos WHERE id = ?");
+  $stmt->execute([$grupo_id]);
+  if ($stmt->fetchColumn() == 0) {
+    exit("Grupo no válido.");
+  }
 }
 
 $stmt = $pdo->prepare("INSERT INTO empresas (nombre, grupo_id) VALUES (?, ?)");


### PR DESCRIPTION
## Summary
- let admins create a company without assigning it to a group
- show 'Ninguno' when a company has no group

## Testing
- `php` interpreter not available so syntax checks could not be run

------
https://chatgpt.com/codex/tasks/task_e_684b431a2e288327b3ccf4b4393717c7