### PR TITLE
Reuse deleted record IDs

### DIFF
--- a/Web/crear_proyecto.php
+++ b/Web/crear_proyecto.php
@@ -14,9 +14,10 @@ $descripcion = trim($_POST['descripcion'] ?? '');
 $estado = $_POST['estado'] ?? 'No iniciado';
 $creador = $_SESSION['usuario_id'];
 
-$pdo->prepare("INSERT INTO proyectos (nombre, descripcion, estado, creador_id) VALUES (?, ?, ?, ?)")
-    ->execute([$nombre, $descripcion, $estado, $creador]);
-$proyecto_id = $pdo->lastInsertId();
+$id = obtenerSiguienteId($pdo, 'proyectos');
+$pdo->prepare("INSERT INTO proyectos (id, nombre, descripcion, estado, creador_id) VALUES (?, ?, ?, ?, ?)")
+    ->execute([$id, $nombre, $descripcion, $estado, $creador]);
+$proyecto_id = $id;
 
 if (!empty($_POST['usuarios_seleccionados'])) {
     $stmt = $pdo->prepare("INSERT INTO proyecto_usuario (proyecto_id, usuario_id) VALUES (?, ?)");

--- a/Web/db.php
+++ b/Web/db.php
@@ -7,3 +7,21 @@ $pdo = new PDO(
   DB_PASS
 );
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+/**
+ * Devuelve el ID más pequeño no utilizado en una tabla.
+ */
+function obtenerSiguienteId(PDO $pdo, string $tabla): int {
+    $stmt = $pdo->query("SELECT id FROM {$tabla} ORDER BY id");
+    $ids = $stmt->fetchAll(PDO::FETCH_COLUMN, 0);
+    $nextId = 1;
+    foreach ($ids as $id) {
+        $id = (int)$id;
+        if ($id === $nextId) {
+            $nextId++;
+        } elseif ($id > $nextId) {
+            break;
+        }
+    }
+    return $nextId;
+}

--- a/Web/empresas.php
+++ b/Web/empresas.php
@@ -81,8 +81,9 @@ if (isset($_POST['grupo_id']) && $_POST['grupo_id'] !== '') {
   }
 }
 
-$stmt = $pdo->prepare("INSERT INTO empresas (nombre, grupo_id) VALUES (?, ?)");
-$stmt->execute([$nombre, $grupo_id]);
+$id = obtenerSiguienteId($pdo, 'empresas');
+$stmt = $pdo->prepare("INSERT INTO empresas (id, nombre, grupo_id) VALUES (?, ?, ?)");
+$stmt->execute([$id, $nombre, $grupo_id]);
 
 header("Location: dashboard_admin.php?tab=empresas");
 exit;

--- a/Web/grupos.php
+++ b/Web/grupos.php
@@ -31,8 +31,9 @@ if (isset($_POST['nombre_grupo'])) {
     if ($stmt->fetchColumn() > 0) {
         exit("Ya existe un grupo con ese nombre.");
     }
-    $stmt = $pdo->prepare("INSERT INTO grupos (nombre) VALUES (?)");
-    $stmt->execute([$nombre]);
+    $id = obtenerSiguienteId($pdo, 'grupos');
+    $stmt = $pdo->prepare("INSERT INTO grupos (id, nombre) VALUES (?, ?)");
+    $stmt->execute([$id, $nombre]);
     header("Location: dashboard_admin.php?tab=grupos");
     exit;
 }

--- a/Web/habilidades.php
+++ b/Web/habilidades.php
@@ -21,8 +21,9 @@ if ($stmt->fetchColumn() > 0) {
 }
 
 // Insertar la empresa
-$stmt = $pdo->prepare("INSERT INTO habilidades (nombre) VALUES (?)");
-$stmt->execute([$nombre]);
+$id = obtenerSiguienteId($pdo, 'habilidades');
+$stmt = $pdo->prepare("INSERT INTO habilidades (id, nombre) VALUES (?, ?)");
+$stmt->execute([$id, $nombre]);
 
 header("Location: dashboard_admin.php");
 exit;

--- a/Web/nuevo_proyecto.php
+++ b/Web/nuevo_proyecto.php
@@ -6,9 +6,10 @@ requerirLogin();
 $id_usuario = $_SESSION['usuario_id'];
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['nombre_proyecto'])) {
-  $pdo->prepare("INSERT INTO proyectos (nombre, descripcion, creador_id) VALUES (?, ?, ?)")
-      ->execute([$_POST['nombre_proyecto'], $_POST['descripcion'], $id_usuario]);
-  $proyecto_id = $pdo->lastInsertId();
+  $id = obtenerSiguienteId($pdo, 'proyectos');
+  $pdo->prepare("INSERT INTO proyectos (id, nombre, descripcion, creador_id) VALUES (?, ?, ?, ?)")
+      ->execute([$id, $_POST['nombre_proyecto'], $_POST['descripcion'], $id_usuario]);
+  $proyecto_id = $id;
   if (!empty($_POST['usuarios_seleccionados'])) {
     $stmt = $pdo->prepare("INSERT INTO proyecto_usuario (proyecto_id, usuario_id) VALUES (?, ?)");
     foreach ($_POST['usuarios_seleccionados'] as $uid) {

--- a/Web/oficinas.php
+++ b/Web/oficinas.php
@@ -28,8 +28,9 @@ if ($stmt->fetchColumn() > 0) {
 }
 
 // Insertar la oficina
-$stmt = $pdo->prepare("INSERT INTO oficinas (nombre, empresa_id, ciudad) VALUES (?, ?, ?)");
-$stmt->execute([$nombre, $empresaId, $ciudad]);
+$id = obtenerSiguienteId($pdo, 'oficinas');
+$stmt = $pdo->prepare("INSERT INTO oficinas (id, nombre, empresa_id, ciudad) VALUES (?, ?, ?, ?)");
+$stmt->execute([$id, $nombre, $empresaId, $ciudad]);
 
 header("Location: dashboard_admin.php");
 exit;

--- a/Web/usuarios.php
+++ b/Web/usuarios.php
@@ -35,12 +35,14 @@ if ($stmt->fetchColumn() > 0) {
 $passwordHash = password_hash($_POST['password'], PASSWORD_DEFAULT);
 
 // Insertar usuario
+$id = obtenerSiguienteId($pdo, 'usuarios');
 $stmt = $pdo->prepare("INSERT INTO usuarios (
-  nombre, apellido_paterno, apellido_materno, email,
+  id, nombre, apellido_paterno, apellido_materno, email,
   password_hash, oficina_id, empresa_id, ciudad, es_admin
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)");
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)");
 
 $stmt->execute([
+  $id,
   $_POST['nombre'],
   $_POST['apellido_paterno'],
   $_POST['apellido_materno'] ?? '',


### PR DESCRIPTION
## Summary
- implement `obtenerSiguienteId` helper
- use smallest available id when inserting groups, companies, offices, users, skills and projects

## Testing
- `php -l Web/db.php`
- `php -l Web/grupos.php`
- `php -l Web/empresas.php`
- `php -l Web/habilidades.php`
- `php -l Web/oficinas.php`
- `php -l Web/usuarios.php`
- `php -l Web/crear_proyecto.php`
- `php -l Web/nuevo_proyecto.php`


------
https://chatgpt.com/codex/tasks/task_e_684b45c84bbc8327843bb1ea0d30dcd2