### PR TITLE
Add rename/delete to admin sections

### DIFF
--- a/Web/crear_proyecto.php
+++ b/Web/crear_proyecto.php
@@ -5,6 +5,46 @@ require_once 'auth.php';
 requerirLogin();
 if (!esSuperAdmin()) exit("Acceso denegado");
 
+// ---- Eliminar proyecto ----
+if (isset($_POST['eliminar_proyecto_id'])) {
+    $pid = (int)$_POST['eliminar_proyecto_id'];
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM proyectos WHERE id = ?");
+    $stmt->execute([$pid]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Proyecto no válido.");
+    }
+
+    $stmt = $pdo->prepare("DELETE FROM proyectos WHERE id = ?");
+    $stmt->execute([$pid]);
+
+    header("Location: dashboard_admin.php?tab=proyectos");
+    exit;
+}
+
+// ---- Renombrar proyecto ----
+if (isset($_POST['editar_proyecto_id'], $_POST['nuevo_nombre'])) {
+    $pid = (int)$_POST['editar_proyecto_id'];
+    $nuevo = trim($_POST['nuevo_nombre']);
+
+    if ($nuevo === '') {
+        exit("El nombre del proyecto no puede estar vacío.");
+    }
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM proyectos WHERE id = ?");
+    $stmt->execute([$pid]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Proyecto no válido.");
+    }
+
+    $stmt = $pdo->prepare("UPDATE proyectos SET nombre = ? WHERE id = ?");
+    $stmt->execute([$nuevo, $pid]);
+
+    header("Location: dashboard_admin.php?tab=proyectos");
+    exit;
+}
+
+// ---- Crear nuevo proyecto ----
 if (empty($_POST['nombre_proyecto'])) {
     exit("El nombre del proyecto es obligatorio.");
 }

--- a/Web/dashboard_admin.php
+++ b/Web/dashboard_admin.php
@@ -167,13 +167,26 @@ $tab = $_GET['tab'] ?? 'empresas';
 
         <h2>Oficinas registradas</h2>
         <table>
-          <tr><th>ID</th><th>Nombre</th><th>Empresa</th><th>Ciudad</th></tr>
+          <tr><th>ID</th><th>Nombre</th><th>Empresa</th><th>Ciudad</th><th>Renombrar</th><th>Eliminar</th></tr>
           <?php foreach ($oficinas as $o): ?>
             <tr>
               <td><?= htmlspecialchars($o['id']) ?></td>
               <td><?= htmlspecialchars($o['nombre']) ?></td>
               <td><?= htmlspecialchars($o['empresa_nombre']) ?></td>
               <td><?= htmlspecialchars($o['ciudad']) ?></td>
+              <td>
+                <form action="oficinas.php" method="POST">
+                  <input type="hidden" name="editar_oficina_id" value="<?= $o['id'] ?>">
+                  <input type="text" name="nuevo_nombre" required placeholder="Nuevo nombre">
+                  <button>Cambiar</button>
+                </form>
+              </td>
+              <td>
+                <form action="oficinas.php" method="POST" onsubmit="return confirm('¿Borrar oficina?');">
+                  <input type="hidden" name="eliminar_oficina_id" value="<?= $o['id'] ?>">
+                  <button>Eliminar</button>
+                </form>
+              </td>
             </tr>
           <?php endforeach; ?>
         </table>
@@ -220,6 +233,8 @@ $tab = $_GET['tab'] ?? 'empresas';
             <th>Oficina</th>
             <th>Ciudad</th>
             <th>Es admin</th>
+            <th>Renombrar</th>
+            <th>Eliminar</th>
           </tr>
           <?php foreach ($usuarios as $u): ?>
             <tr>
@@ -230,6 +245,19 @@ $tab = $_GET['tab'] ?? 'empresas';
               <td><?= htmlspecialchars($u['oficina']) ?></td>
               <td><?= htmlspecialchars($u['ciudad']) ?></td>
               <td><?= $u['es_admin'] ? 'Sí' : 'No' ?></td>
+              <td>
+                <form action="usuarios.php" method="POST">
+                  <input type="hidden" name="editar_usuario_id" value="<?= $u['id'] ?>">
+                  <input type="text" name="nuevo_nombre" required placeholder="Nuevo nombre">
+                  <button>Cambiar</button>
+                </form>
+              </td>
+              <td>
+                <form action="usuarios.php" method="POST" onsubmit="return confirm('¿Borrar usuario?');">
+                  <input type="hidden" name="eliminar_usuario_id" value="<?= $u['id'] ?>">
+                  <button>Eliminar</button>
+                </form>
+              </td>
             </tr>
           <?php endforeach; ?>
         </table>
@@ -268,6 +296,8 @@ $tab = $_GET['tab'] ?? 'empresas';
             <th>Descripci&oacute;n</th>
             <th>Estado</th>
             <th>Participantes</th>
+            <th>Renombrar</th>
+            <th>Eliminar</th>
           </tr>
           <?php foreach ($proyectos as $p): ?>
             <tr>
@@ -276,6 +306,19 @@ $tab = $_GET['tab'] ?? 'empresas';
               <td><?= htmlspecialchars($p['descripcion']) ?></td>
               <td><?= htmlspecialchars($p['estado']) ?></td>
               <td><?= htmlspecialchars($p['participantes']) ?></td>
+              <td>
+                <form action="crear_proyecto.php" method="POST">
+                  <input type="hidden" name="editar_proyecto_id" value="<?= $p['id'] ?>">
+                  <input type="text" name="nuevo_nombre" required placeholder="Nuevo nombre">
+                  <button>Cambiar</button>
+                </form>
+              </td>
+              <td>
+                <form action="crear_proyecto.php" method="POST" onsubmit="return confirm('¿Borrar proyecto?');">
+                  <input type="hidden" name="eliminar_proyecto_id" value="<?= $p['id'] ?>">
+                  <button>Eliminar</button>
+                </form>
+              </td>
             </tr>
           <?php endforeach; ?>
         </table>
@@ -289,11 +332,24 @@ $tab = $_GET['tab'] ?? 'empresas';
 
         <h2>Habilidades registradas</h2>
         <table>
-          <tr><th>ID</th><th>Nombre</th></tr>
+          <tr><th>ID</th><th>Nombre</th><th>Renombrar</th><th>Eliminar</th></tr>
           <?php foreach ($habilidades as $h): ?>
           <tr>
             <td><?= htmlspecialchars($h['id']) ?></td>
             <td><?= htmlspecialchars($h['nombre']) ?></td>
+            <td>
+              <form action="habilidades.php" method="POST">
+                <input type="hidden" name="editar_habilidad_id" value="<?= $h['id'] ?>">
+                <input type="text" name="nuevo_nombre" required placeholder="Nuevo nombre">
+                <button>Cambiar</button>
+              </form>
+            </td>
+            <td>
+              <form action="habilidades.php" method="POST" onsubmit="return confirm('¿Borrar habilidad?');">
+                <input type="hidden" name="eliminar_habilidad_id" value="<?= $h['id'] ?>">
+                <button>Eliminar</button>
+              </form>
+            </td>
           </tr>
           <?php endforeach; ?>
         </table>

--- a/Web/habilidades.php
+++ b/Web/habilidades.php
@@ -5,26 +5,68 @@ require_once 'auth.php';
 requerirLogin();
 if (!esSuperAdmin()) exit("Acceso denegado");
 
-// Verificar que el nombre no esté vacío
-if (empty($_POST['nombre_habilidad'])) {
-  exit("El nombre de la habilidad no puede estar vacío.");
+// ---- Eliminar habilidad ----
+if (isset($_POST['eliminar_habilidad_id'])) {
+    $hid = (int)$_POST['eliminar_habilidad_id'];
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM habilidades WHERE id = ?");
+    $stmt->execute([$hid]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Habilidad no válida.");
+    }
+
+    $stmt = $pdo->prepare("DELETE FROM habilidades WHERE id = ?");
+    $stmt->execute([$hid]);
+
+    header("Location: dashboard_admin.php?tab=habilidades");
+    exit;
 }
 
-// Limpiar y normalizar
+// ---- Renombrar habilidad ----
+if (isset($_POST['editar_habilidad_id'], $_POST['nuevo_nombre'])) {
+    $hid = (int)$_POST['editar_habilidad_id'];
+    $nuevo = trim($_POST['nuevo_nombre']);
+
+    if ($nuevo === '') {
+        exit("El nombre de la habilidad no puede estar vacío.");
+    }
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM habilidades WHERE id = ?");
+    $stmt->execute([$hid]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Habilidad no válida.");
+    }
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM habilidades WHERE nombre = ? AND id != ?");
+    $stmt->execute([$nuevo, $hid]);
+    if ($stmt->fetchColumn() > 0) {
+        exit("Ya existe una habilidad con ese nombre.");
+    }
+
+    $stmt = $pdo->prepare("UPDATE habilidades SET nombre = ? WHERE id = ?");
+    $stmt->execute([$nuevo, $hid]);
+
+    header("Location: dashboard_admin.php?tab=habilidades");
+    exit;
+}
+
+// ---- Crear nueva habilidad ----
+if (empty($_POST['nombre_habilidad'])) {
+    exit("El nombre de la habilidad no puede estar vacío.");
+}
+
 $nombre = trim($_POST['nombre_habilidad']);
 
-// Comprobar si ya existe una empresa con ese nombre
 $stmt = $pdo->prepare("SELECT COUNT(*) FROM habilidades WHERE nombre = ?");
 $stmt->execute([$nombre]);
 if ($stmt->fetchColumn() > 0) {
-  exit("Ya existe una habilidad con ese nombre.");
+    exit("Ya existe una habilidad con ese nombre.");
 }
 
-// Insertar la empresa
 $id = obtenerSiguienteId($pdo, 'habilidades');
 $stmt = $pdo->prepare("INSERT INTO habilidades (id, nombre) VALUES (?, ?)");
 $stmt->execute([$id, $nombre]);
 
-header("Location: dashboard_admin.php");
+header("Location: dashboard_admin.php?tab=habilidades");
 exit;
 ?>

--- a/Web/oficinas.php
+++ b/Web/oficinas.php
@@ -5,33 +5,81 @@ require_once 'auth.php';
 requerirLogin();
 if (!esSuperAdmin()) exit("Acceso denegado");
 
-// Validar que los campos estén presentes
-if (empty($_POST['nombre_oficina']) || empty($_POST['ciudad']) || empty($_POST['empresa_id'])) {
-  exit("Faltan datos obligatorios.");
+// ---- Eliminar oficina ----
+if (isset($_POST['eliminar_oficina_id'])) {
+    $oficina_id = (int)$_POST['eliminar_oficina_id'];
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM oficinas WHERE id = ?");
+    $stmt->execute([$oficina_id]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Oficina no válida.");
+    }
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM usuarios WHERE oficina_id = ?");
+    $stmt->execute([$oficina_id]);
+    if ($stmt->fetchColumn() > 0) {
+        exit("No se puede eliminar la oficina porque tiene usuarios asociados.");
+    }
+
+    $stmt = $pdo->prepare("DELETE FROM oficinas WHERE id = ?");
+    $stmt->execute([$oficina_id]);
+
+    header("Location: dashboard_admin.php?tab=oficinas");
+    exit;
 }
 
-// Limpiar y normalizar entradas
+// ---- Renombrar oficina ----
+if (isset($_POST['editar_oficina_id'], $_POST['nuevo_nombre'])) {
+    $oficina_id = (int)$_POST['editar_oficina_id'];
+    $nuevo_nombre = trim($_POST['nuevo_nombre']);
+
+    if ($nuevo_nombre === '') {
+        exit("El nombre de la oficina no puede estar vacío.");
+    }
+
+    $stmt = $pdo->prepare("SELECT * FROM oficinas WHERE id = ?");
+    $stmt->execute([$oficina_id]);
+    $oficina = $stmt->fetch();
+    if (!$oficina) {
+        exit("Oficina no válida.");
+    }
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM oficinas WHERE nombre = ? AND ciudad = ? AND empresa_id = ? AND id != ?");
+    $stmt->execute([$nuevo_nombre, $oficina['ciudad'], $oficina['empresa_id'], $oficina_id]);
+    if ($stmt->fetchColumn() > 0) {
+        exit("Ya existe una oficina con ese nombre en esa ciudad.");
+    }
+
+    $stmt = $pdo->prepare("UPDATE oficinas SET nombre = ? WHERE id = ?");
+    $stmt->execute([$nuevo_nombre, $oficina_id]);
+
+    header("Location: dashboard_admin.php?tab=oficinas");
+    exit;
+}
+
+// ---- Crear nueva oficina ----
+if (empty($_POST['nombre_oficina']) || empty($_POST['ciudad']) || empty($_POST['empresa_id'])) {
+    exit("Faltan datos obligatorios.");
+}
+
 $nombre = trim($_POST['nombre_oficina']);
 $ciudad = trim($_POST['ciudad']);
 $empresaId = intval($_POST['empresa_id']);
 
-// Validar que no estén vacíos tras limpiar
 if ($nombre === '' || $ciudad === '' || $empresaId === 0) {
-  exit("Los campos no pueden estar vacíos.");
+    exit("Los campos no pueden estar vacíos.");
 }
 
-// Comprobar si ya existe una oficina con ese nombre en esa ciudad
 $stmt = $pdo->prepare("SELECT COUNT(*) FROM oficinas WHERE nombre = ? AND ciudad = ? AND empresa_id = ?");
 $stmt->execute([$nombre, $ciudad, $empresaId]);
 if ($stmt->fetchColumn() > 0) {
-  exit("Ya existe una oficina con ese nombre en esa ciudad.");
+    exit("Ya existe una oficina con ese nombre en esa ciudad.");
 }
 
-// Insertar la oficina
 $id = obtenerSiguienteId($pdo, 'oficinas');
 $stmt = $pdo->prepare("INSERT INTO oficinas (id, nombre, empresa_id, ciudad) VALUES (?, ?, ?, ?)");
 $stmt->execute([$id, $nombre, $empresaId, $ciudad]);
 
-header("Location: dashboard_admin.php");
+header("Location: dashboard_admin.php?tab=oficinas");
 exit;
 ?>

--- a/Web/usuarios.php
+++ b/Web/usuarios.php
@@ -5,7 +5,46 @@ require_once 'auth.php';
 requerirLogin();
 if (!esSuperAdmin()) exit("Acceso denegado");
 
-// Validaciones mínimas
+// ---- Eliminar usuario ----
+if (isset($_POST['eliminar_usuario_id'])) {
+    $uid = (int)$_POST['eliminar_usuario_id'];
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM usuarios WHERE id = ?");
+    $stmt->execute([$uid]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Usuario no válido.");
+    }
+
+    $stmt = $pdo->prepare("DELETE FROM usuarios WHERE id = ?");
+    $stmt->execute([$uid]);
+
+    header("Location: dashboard_admin.php?tab=usuarios");
+    exit;
+}
+
+// ---- Renombrar usuario (solo nombre) ----
+if (isset($_POST['editar_usuario_id'], $_POST['nuevo_nombre'])) {
+    $uid = (int)$_POST['editar_usuario_id'];
+    $nuevo = trim($_POST['nuevo_nombre']);
+
+    if ($nuevo === '') {
+        exit("El nombre no puede estar vacío.");
+    }
+
+    $stmt = $pdo->prepare("SELECT COUNT(*) FROM usuarios WHERE id = ?");
+    $stmt->execute([$uid]);
+    if ($stmt->fetchColumn() == 0) {
+        exit("Usuario no válido.");
+    }
+
+    $stmt = $pdo->prepare("UPDATE usuarios SET nombre = ? WHERE id = ?");
+    $stmt->execute([$nuevo, $uid]);
+
+    header("Location: dashboard_admin.php?tab=usuarios");
+    exit;
+}
+
+// ---- Crear nuevo usuario ----
 if (
   empty($_POST['nombre']) ||
   empty($_POST['apellido_paterno']) ||
@@ -54,6 +93,6 @@ $stmt->execute([
   isset($_POST['es_admin']) ? 1 : 0
 ]);
 
-header("Location: dashboard_admin.php");
+header("Location: dashboard_admin.php?tab=usuarios");
 exit;
 ?>


### PR DESCRIPTION
## Summary
- allow editing and removing offices, users, skills and projects
- show rename/delete forms for those tables in admin dashboard

## Testing
- `php -l Web/oficinas.php`
- `php -l Web/usuarios.php`
- `php -l Web/habilidades.php`
- `php -l Web/crear_proyecto.php`
- `php -l Web/dashboard_admin.php`


------
https://chatgpt.com/codex/tasks/task_e_684b47dd0cb08327a493509b4a9d94ee